### PR TITLE
feat: SDKI-60: Remove base64 encoding from auth token

### DIFF
--- a/SeamlessPayCore/Classes/APIClient/APIClient.swift
+++ b/SeamlessPayCore/Classes/APIClient/APIClient.swift
@@ -537,10 +537,7 @@ private extension APIClient {
     authorization: String?,
     contentLength: Int?
   ) -> [String: String] {
-    let authHeaderValue = authorization?
-      .data(using: .utf8)
-      .flatMap { $0.base64EncodedString(options: []) }
-      .flatMap { "Bearer " + $0 }
+    let authHeaderValue = authorization.flatMap { "Bearer " + $0 }
     let contentLength = contentLength.flatMap { String($0) }
 
     return [


### PR DESCRIPTION
### Task
[SDKI-60](https://seamlesspay.atlassian.net/browse/SDKI-60)
### Description
Removed Base64 encoding from the creation of the authentication token header

[SDKI-60]: https://seamlesspay.atlassian.net/browse/SDKI-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ